### PR TITLE
Feature/build taco details

### DIFF
--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -2,6 +2,7 @@ import { Route } from 'react-router-dom'
 
 import Header from '../Header/Header'
 import TacoGenerator from '../TacoGenerator/TacoGenerator'
+import TacoDetails from '../TacoDetails/TacoDetails'
 
 import './App.css';
 
@@ -14,7 +15,7 @@ function App() {
           <TacoGenerator />
         </Route>
         <Route exact path='/details'>
-          
+          <TacoDetails />
         </Route>
       </main>
     </div>

--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -26,6 +26,8 @@ function App() {
       <main>
         <Route exact path='/'>
           <TacoGenerator 
+            taco={taco}
+            error={error}
             handleClick={generateTaco}
           />
         </Route>

--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -1,12 +1,25 @@
+import { useState } from 'react'
 import { Route } from 'react-router-dom'
 
 import Header from '../Header/Header'
 import TacoGenerator from '../TacoGenerator/TacoGenerator'
 import TacoDetails from '../TacoDetails/TacoDetails'
 
+import { getTacoData } from '../../utils/apiCalls'
+import { ITaco } from '../../utils/types'
+
 import './App.css';
 
 function App() {
+  const [taco, setTaco] = useState<ITaco | null>(null)
+  const [error, setError] = useState('')
+
+  const generateTaco = () => {
+    getTacoData()
+      .then(data => setTaco(data))
+      .catch(error => setError(error.message))
+  }
+
   return (
     <div className="App">
       <Header />

--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -25,7 +25,9 @@ function App() {
       <Header />
       <main>
         <Route exact path='/'>
-          <TacoGenerator />
+          <TacoGenerator 
+            handleClick={generateTaco}
+          />
         </Route>
         <Route exact path='/details'>
           <TacoDetails />

--- a/src/ Components/TacoDetails/TacoDetails.tsx
+++ b/src/ Components/TacoDetails/TacoDetails.tsx
@@ -1,0 +1,7 @@
+import './TacoDetails.css'
+
+export default function TacoDetails() {
+  return (
+    <div></div>
+  )
+}

--- a/src/ Components/TacoGenerator/TacoGenerator.css
+++ b/src/ Components/TacoGenerator/TacoGenerator.css
@@ -22,9 +22,9 @@
   font-size: 1.25em;
 }
 
-.generation-msg {
-  /* margin-bottom: 48px; */
-}
+/* .generation-msg {
+  margin-bottom: 48px;
+} */
 
 .taco-generator > button,
 .taco-generator > a {

--- a/src/ Components/TacoGenerator/TacoGenerator.tsx
+++ b/src/ Components/TacoGenerator/TacoGenerator.tsx
@@ -8,16 +8,7 @@ import { ITaco } from '../../utils/types'
 import { getTacoData } from '../../utils/apiCalls'
 import './TacoGenerator.css'
 
-export default function TacoGenerator() {
-  const [taco, setTaco] = useState<ITaco | null>(null)
-  const [error, setError] = useState('')
-
-  const generateTaco = () => {
-    getTacoData()
-      .then(data => setTaco(data))
-      .catch(error => setError(error.message))
-  }
-
+export default function TacoGenerator({taco, error, handleClick}: {handleClick: () => void}) {
   const formatTacoText = () => {
     return (
       <p className='taco-text'>{`${taco?.base} with ${taco?.condiment}, ganished with ${taco?.mixin} topped off with ${taco?.seasoning} and wrapped in a delicious ${taco?.shell}`}</p>
@@ -37,7 +28,7 @@ export default function TacoGenerator() {
       {!taco &&
         <PrimaryButton
           text='Generate Taco'
-          handleClick={generateTaco}
+          handleClick={handleClick}
         />
       }
       {taco &&
@@ -49,7 +40,7 @@ export default function TacoGenerator() {
           </Link>
           <SecondaryButton 
             text='Generate another?'
-            handleClick={generateTaco}
+            handleClick={handleClick}
           />
         </>
       }

--- a/src/ Components/TacoGenerator/TacoGenerator.tsx
+++ b/src/ Components/TacoGenerator/TacoGenerator.tsx
@@ -1,14 +1,18 @@
-import { useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import PrimaryButton from '../Buttons/PrimaryButton/PrimaryButton'
 import SecondaryButton from '../Buttons/SecondaryButton/SecondaryButton'
 
 import { ITaco } from '../../utils/types'
-import { getTacoData } from '../../utils/apiCalls'
 import './TacoGenerator.css'
 
-export default function TacoGenerator({taco, error, handleClick}: {handleClick: () => void}) {
+interface IProps {
+  taco: ITaco,
+  error: string,
+  handleClick: () => void
+}
+
+export default function TacoGenerator({taco, error, handleClick}: IProps) {
   const formatTacoText = () => {
     return (
       <p className='taco-text'>{`${taco?.base} with ${taco?.condiment}, ganished with ${taco?.mixin} topped off with ${taco?.seasoning} and wrapped in a delicious ${taco?.shell}`}</p>


### PR DESCRIPTION
To make the TacoDetails work, App is now holding on to the primary chuck of state and will pass down necessary props to each view (which will be functional components).

Removed 'useState()' in TacoGenerator and moved to App - all fetching has also been moved to App. 