### PR TITLE
Refactoring/update taco details rendering

### DIFF
--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -13,6 +13,7 @@ import './App.css';
 
 function App() {
   const [tacoDetails, setTacoDetails] = useState<IShapedTacoDetails | null>(null)
+  const [generatedTacos, setGeneratedTacos] = useState<IShapedTacoDetails[]>([])
   const [favorites, setFavorites] = useState<IShapedTacoDetails[]>([])
   const [error, setError] = useState('')
 
@@ -20,7 +21,9 @@ function App() {
     getTacoDetails()
       .then(data => {
         window.sessionStorage.setItem('tacoDetails', JSON.stringify(data))
+
         setTacoDetails(data)
+        setGeneratedTacos([...generatedTacos, data])
       })
       .catch(error => setError(error.message))
   }

--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -10,17 +10,22 @@ import { getTacoDetails } from '../../utils/apiCalls'
 import { IShapedTacoDetails } from '../../utils/utilites'
 
 import './App.css';
+import { useEffect } from 'react'
 
 function App() {
   const [tacoDetails, setTacoDetails] = useState<IShapedTacoDetails | null>(null)
-  const [generatedTacos, setGeneratedTacos] = useState<IShapedTacoDetails[]>([])
+  const [generatedTacos, setGeneratedTacos] = useState<IShapedTacoDetails[]>(() => {
+    if (window.sessionStorage.getItem('generatedTacos')) {
+      return JSON.parse(window.sessionStorage.getItem('generatedTacos'))
+    } else {
+      return []
+    }
+  })
   const [error, setError] = useState('')
 
   const generateTaco = () => {
     getTacoDetails()
       .then(data => {
-        window.sessionStorage.setItem('tacoDetails', JSON.stringify(data))
-
         setTacoDetails(data)
         setGeneratedTacos([...generatedTacos, data])
       })
@@ -39,11 +44,13 @@ function App() {
     )
   }
 
-  console.log(generatedTacos)
-
   const getFavorites = () => {
     return generatedTacos.filter(taco => taco.isFavorited)
   }
+
+  useEffect(() => {
+    window.sessionStorage.setItem('generatedTacos', JSON.stringify(generatedTacos))
+  })
 
   return (
     <div className="App">

--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -14,7 +14,6 @@ import './App.css';
 function App() {
   const [tacoDetails, setTacoDetails] = useState<IShapedTacoDetails | null>(null)
   const [generatedTacos, setGeneratedTacos] = useState<IShapedTacoDetails[]>([])
-  const [favorites, setFavorites] = useState<IShapedTacoDetails[]>([])
   const [error, setError] = useState('')
 
   const generateTaco = () => {
@@ -29,13 +28,21 @@ function App() {
   }
 
   const toggleFavorite = (tacoDetails: IShapedTacoDetails) => {
-    const foundFavorite = favorites.find(taco => taco.id === tacoDetails.id)
+    setGeneratedTacos(
+      generatedTacos.map(taco => {
+        if (taco.id === tacoDetails.id) {
+          taco.isFavorited = !(taco.isFavorited)
+        }
 
-    if (foundFavorite) {
-      setFavorites(favorites.filter(taco => taco.id !== tacoDetails.id))
-    } else {
-      setFavorites([...favorites, tacoDetails])
-    }
+        return taco
+      })
+    )
+  }
+
+  console.log(generatedTacos)
+
+  const getFavorites = () => {
+    return generatedTacos.filter(taco => taco.isFavorited)
   }
 
   return (
@@ -62,7 +69,7 @@ function App() {
           }
         </Route>
         <Route exact path='/to-share'>
-          <ToShare favorites={favorites}/>
+          <ToShare favorites={getFavorites()}/>
         </Route>
       </main>
     </div>

--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Route } from 'react-router-dom'
 
 import Header from '../Header/Header'
@@ -8,9 +8,7 @@ import ToShare from '../ToShare/ToShare'
 
 import { getTacoDetails } from '../../utils/apiCalls'
 import { IShapedTacoDetails } from '../../utils/utilites'
-
 import './App.css';
-import { useEffect } from 'react'
 
 function App() {
   const [tacoDetails, setTacoDetails] = useState<IShapedTacoDetails | null>(null)
@@ -63,17 +61,18 @@ function App() {
             handleClick={generateTaco}
           />
         </Route>
-        <Route exact path='/details'>
-          {(tacoDetails || window.sessionStorage.getItem('tacoDetails')) &&
-            <TacoDetails 
-              tacoDetails={
-                tacoDetails
-                  ? tacoDetails
-                  : JSON.parse(window.sessionStorage.getItem('tacoDetails'))
-              }
-              handleClick={toggleFavorite}
-            />
-          }
+        <Route 
+          exact path='/details/:id'
+          render={({ match }) => {
+            return (
+              generatedTacos &&
+                <TacoDetails 
+                  tacoDetails={generatedTacos.find(taco => taco.id === match.params.id)}
+                  handleClick={toggleFavorite}
+                />
+            )
+          }}
+        >
         </Route>
         <Route exact path='/to-share'>
           <ToShare favorites={getFavorites()}/>

--- a/src/ Components/TacoGenerator/TacoGenerator.tsx
+++ b/src/ Components/TacoGenerator/TacoGenerator.tsx
@@ -31,7 +31,7 @@ export default function TacoGenerator({tacoDetails, error, handleClick}: IProps)
       }
       {tacoDetails &&
         <>
-          <Link to='/details'>
+          <Link to={`/details/${tacoDetails.id}`}>
             <PrimaryButton 
               text='View Details'
             />

--- a/src/ Components/ToShare/ToShare.tsx
+++ b/src/ Components/ToShare/ToShare.tsx
@@ -7,7 +7,7 @@ export default function ToShare({favorites}: {favorites: IShapedTacoDetails[]}) 
   const favoriteDisplays = favorites.map(favorite => {
     return (
       <Link
-        to={`to-share${favorite.id}`} 
+        to={`details/${favorite.id}`} 
         key={favorite.id}
         className='favorite-display'
       >

--- a/src/utils/utilites.tsx
+++ b/src/utils/utilites.tsx
@@ -7,7 +7,8 @@ interface ITacoDetails {
 
 export interface IShapedTacoDetails extends ITacoData {
   id: string,
-  image: string
+  image: string,
+  isFavorited: boolean
 }
 
 export interface ITacoData {
@@ -49,7 +50,8 @@ export function shapeTacoDetails(data: ITacoDetails): IShapedTacoDetails {
       name: shell.name,
       url: shell.url
     },
-    image: data.tacoImage.urls.regular
+    image: data.tacoImage.urls.regular,
+    isFavorited: false
   }
 }
 


### PR DESCRIPTION
Removed favorites from App state and replace with a general-purpose array for holding all generated tacos - this array is then utilized to view a taco's details on TacoDetails. Session storage is now keeping track of the entirety of generated tacos instead of a single taco.