### PR TITLE
Feature/add favorite removal

### DIFF
--- a/src/ Components/App/App.tsx
+++ b/src/ Components/App/App.tsx
@@ -91,7 +91,10 @@ function App() {
             return (
               <>
                 <main>
-                  <Favorites favorites={getFavorites()} />
+                  <Favorites 
+                    favorites={getFavorites()}
+                    handleClick={toggleFavorite} 
+                  />
                 </main>
                 <Footer 
                   isHome={false}

--- a/src/ Components/Favorites/Favorites.css
+++ b/src/ Components/Favorites/Favorites.css
@@ -5,7 +5,7 @@
 
 .favorites-title {
   width: max-content;
-  margin-bottom: 16px;
+  margin-bottom: 24px;
   padding-left: 8px;
   border-left: solid 4px #FE2C55;
   font-size: 1.25em;

--- a/src/ Components/Favorites/Favorites.css
+++ b/src/ Components/Favorites/Favorites.css
@@ -6,6 +6,8 @@
 .favorites-title {
   width: max-content;
   margin-bottom: 16px;
+  padding-left: 8px;
+  border-left: solid 4px #FE2C55;
   font-size: 1.25em;
   font-weight: 700;
 }
@@ -21,15 +23,15 @@
 }
 
 .favorite-display .primary-toppings {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   font-size: 1.25em;
   font-weight: 600;
 }
 
 .favorite-display .secondary-toppings {
-  margin: 0 0 16px 8px;
-  padding-left: 8px;
-  border-left: solid 4px #FE2C55;
+  margin-bottom: 16px;
+  /* padding-left: 8px;
+  border-left: solid 4px #FE2C55; */
   font-size: 1em;
   font-weight: lighter;
 }

--- a/src/ Components/Favorites/Favorites.css
+++ b/src/ Components/Favorites/Favorites.css
@@ -34,6 +34,12 @@
   font-weight: lighter;
 }
 
-.favorite-display a {
+.favorite-display-btns {
+  width: max-content;
   align-self: flex-end;
+  border: unset;
+}
+
+.favorite-display-btns > .secondary-btn {
+  margin-right: 16px;
 }

--- a/src/ Components/Favorites/Favorites.tsx
+++ b/src/ Components/Favorites/Favorites.tsx
@@ -34,7 +34,7 @@ export default function Favorites({ favorites, handleClick }: IProps) {
 
   return (
     <div className='favorites'>
-      <h1 className='favorites-title'>Tacos to Share</h1>
+      <h1 className='favorites-title'>My Sharable Tacos</h1>
       {favoriteDisplays.length
         ? favoriteDisplays
         : <p className='no-favorites-msg'>No tacos added yet. Find a sharable taco!</p>

--- a/src/ Components/Favorites/Favorites.tsx
+++ b/src/ Components/Favorites/Favorites.tsx
@@ -1,11 +1,17 @@
 import { Link } from 'react-router-dom'
 
 import PrimaryButton from '../Buttons/PrimaryButton/PrimaryButton'
+import SecondaryButton from '../Buttons/SecondaryButton/SecondaryButton'
 
 import { formatDetailsText, IShapedTacoDetails } from "../../utils/utilites"
 import './Favorites.css'
 
-export default function Favorites({favorites}: {favorites: IShapedTacoDetails[]}) {
+interface IProps {
+  favorites: IShapedTacoDetails[],
+  handleClick: (tacoDetails: IShapedTacoDetails) => void
+}
+
+export default function Favorites({ favorites, handleClick }: IProps) {
   const favoriteDisplays = favorites.map(favorite => {
     return (
       <div
@@ -13,9 +19,15 @@ export default function Favorites({favorites}: {favorites: IShapedTacoDetails[]}
         className='favorite-display'
       >
         {formatDetailsText(favorite)}
-        <Link to={`details/${favorite.id}`}>
-          <PrimaryButton text='View Details' />
-        </Link>
+        <fieldset className='favorite-display-btns'>
+          <SecondaryButton 
+            text='Remove'
+            handleClick={() => handleClick(favorite)}
+          />
+          <Link to={`details/${favorite.id}`}>
+            <PrimaryButton text='View Details' />
+          </Link>
+        </fieldset>
       </div>
     )
   })

--- a/src/ Components/Favorites/Favorites.tsx
+++ b/src/ Components/Favorites/Favorites.tsx
@@ -37,7 +37,7 @@ export default function Favorites({ favorites, handleClick }: IProps) {
       <h1 className='favorites-title'>My Sharable Tacos</h1>
       {favoriteDisplays.length
         ? favoriteDisplays
-        : <p className='no-favorites-msg'>No tacos added yet. Find a sharable taco!</p>
+        : <p className='no-favorites-msg'>No tacos here. Find a sharable taco!</p>
       }
     </div>
   )

--- a/src/ Components/TacoGenerator/TacoGenerator.css
+++ b/src/ Components/TacoGenerator/TacoGenerator.css
@@ -14,7 +14,7 @@
 
 .greeting {
   position: sticky;
-  margin-bottom: 16px;
+  margin-bottom: 24px;
   font-size: 1.25em;
   font-weight: 600;
 }
@@ -28,7 +28,6 @@
 
 .generation-msg,
 .display-text {
-  /* margin: 16px; */
   font-size: 1.25em;
 }
 

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -16,7 +16,7 @@ async function getTacoData() {
 }
 
 async function getTacoImage() {
-  const resp = await fetch('https://api.unsplash.com/photos/random?query=taco', { headers: { Authorization: 'Client-ID SVh3qN5qzhFdLisOJQj9vdBuBYOFNI6FNPrWcweQsZM' } });
+  const resp = await fetch('https://api.unsplash.com/photos/random?query=tortilla', { headers: { Authorization: 'Client-ID SVh3qN5qzhFdLisOJQj9vdBuBYOFNI6FNPrWcweQsZM' } });
   return checkResponse(resp);
 }
 


### PR DESCRIPTION
To build a better UX, added a 'Remove' button to each favorite taco within the Favorites view. When this button is selected, the taco is immediately removed, preventing the extra step of accessing the taco's details view. 

Updated the title styling for the Favorites view to help reduce clashing with the content below.